### PR TITLE
Change URL for badges.mozilla.org origin

### DIFF
--- a/distributions.tf
+++ b/distributions.tf
@@ -23,7 +23,8 @@ module "campus-mozilla-community" {
 module "badges-mozilla-org" {
   source              = "git://github.com/mozilla/partinfra-terraform-cloudfrontssl.git"
 
-  origin_domain_name  = "badges.mozilla.org.s3-website-us-east-1.amazonaws.com"
+  origin_domain_name  = "s3.amazonaws.com"
+  origin_path         = "/badges.mozilla.org"
   origin_id           = "s3-badges-mozilla-org"
   alias               = "badges.mozilla.org"
   comment             = "Bug 1230266"


### PR DESCRIPTION
Using a bucket name with dots in it breaks the cert for the static hosting domain.