### PR TITLE
Remove user check from AdminAccessRole

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -16,14 +16,6 @@ data "aws_iam_policy_document" "admin-access-assume-role-policy" {
         }
 
         condition {
-            test = "StringEquals"
-            variable = "aws:PrincipalType"
-            values = [
-                "user",
-            ]
-        }
-
-        condition {
             test = "Bool"
             variable = "aws:MultiFactorAuthPresent"
             values = [


### PR DESCRIPTION
Considering we're listing specific users, it doesn't make sense to check if they're users.

(also this makes it not work)