### PR TITLE
Add policies to S3 buckets

### DIFF
--- a/backups.tf
+++ b/backups.tf
@@ -1,3 +1,34 @@
+data "aws_iam_policy_document" "jenkins-backup-bucket-policy" {
+
+    statement {
+        effect = "Deny"
+        actions = [
+            "s3:*",
+        ]
+
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+
+        resources = [
+            "${aws_s3_bucket.jenkins-duplicity-backup.arn}",
+            "${aws_s3_bucket.jenkins-public-duplicity-backup.arn}",
+            "${aws_s3_bucket.jenkins-duplicity-backup.arn}/*",
+            "${aws_s3_bucket.jenkins-public-duplicity-backup.arn}/*"
+        ]
+
+        condition {
+            test = "StringNotLike"
+            variable = "aws:userId"
+            values = [
+                "${aws_iam_role.admin-access-role.unique_id}:*",
+                "${var.aws_account_id}"
+            ]
+        }
+    }
+}
+
 resource "aws_s3_bucket" "jenkins-duplicity-backup" {
     bucket = "jenkins-duplicity-backup"
     acl = "private"
@@ -18,4 +49,14 @@ resource "aws_s3_bucket" "jenkins-public-duplicity-backup" {
         app = "duplicity"
         project = "backup"
     }
+}
+
+resource "aws_s3_bucket_policy" "jenkins-backup-bucket-policy-attachment" {
+  bucket = "${aws_s3_bucket.jenkins-duplicity-backup.id}"
+  policy = "${data.aws_iam_policy_document.jenkins-backup-bucket-policy.json}"
+}
+
+resource "aws_s3_bucket_policy" "jenkins-public-backup-bucket-policy-attachment" {
+  bucket = "${aws_s3_bucket.jenkins-public-duplicity-backup.id}"
+  policy = "${data.aws_iam_policy_document.jenkins-backup-bucket-policy.json}"
 }

--- a/discourse.tf
+++ b/discourse.tf
@@ -8,6 +8,7 @@ module "discourse-production" {
     elasticache_subnet_group            = "${aws_elasticache_subnet_group.elasticache-production-subnet-group.name}"
     fqdn                                = "discourse.mozilla-community.org"
     ssl_certificate                     = "${lookup(var.ssl_certificates, "community-sites-elb-${var.aws_region}")}"
+    aws_account_id                      = "${var.aws_account_id}"
 }
 
 module "discourse-staging" {
@@ -20,4 +21,5 @@ module "discourse-staging" {
     elasticache_subnet_group            = "${aws_elasticache_subnet_group.elasticache-staging-subnet-group.name}"
     fqdn                                = "discourse.staging.paas.mozilla.community"
     ssl_certificate                     = "${lookup(var.ssl_certificates, "community-sites-elb-${var.aws_region}")}"
+    aws_account_id                      = "${var.aws_account_id}"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,14 @@
+variable "community-ops-buckets" {
+    default = [
+        "blog.mozillaindia.org",
+        "discourse-staging-emailin",
+        "equal-rating-wp-content",
+        "guides.mozilla-community.org",
+        "innoprize-hostmaster-email",
+        "mainwp-paas-remote-backups"
+    ]
+}
+
 data "aws_iam_policy_document" "admin-access-assume-role-policy" {
 
     statement {
@@ -271,6 +282,18 @@ data "aws_iam_policy_document" "community-ops-elevated-policy" {
         resources = [
             "arn:aws:iam::${var.aws_account_id}:mfa/$${aws:username}",
         ]
+    }
+
+    statement {
+        effect    = "Allow"
+        actions   = [
+            "s3:*",
+        ]
+
+        resources = "${concat(
+            formatlist("%s%s", "arn:aws:s3:::", var.community-ops-buckets),
+            formatlist("%s%s/*", "arn:aws:s3:::", var.community-ops-buckets)
+        )}"
     }
 }
 

--- a/mesos-cluster.tf
+++ b/mesos-cluster.tf
@@ -17,6 +17,8 @@ module "mesos-cluster-staging" {
     subnet2              = "${aws_subnet.apps-staging-1c.id}"
     subnet3              = "${aws_subnet.apps-staging-1d.id}"
     sns_topic_arn        = "${aws_sns_topic.sns-cloudwatch-partinfra.arn}"
+    aws_account_id       = "${var.aws_account_id}"
+    adminaccessrole-uid  = "${aws_iam_role.admin-access-role.unique_id}"
 }
 
 module "mesos-cluster-production" {
@@ -37,4 +39,6 @@ module "mesos-cluster-production" {
     subnet2              = "${aws_subnet.apps-production-1c.id}"
     subnet3              = "${aws_subnet.apps-production-1d.id}"
     sns_topic_arn        = "${aws_sns_topic.sns-cloudwatch-partinfra.arn}"
+    aws_account_id       = "${var.aws_account_id}"
+    adminaccessrole-uid  = "${aws_iam_role.admin-access-role.unique_id}"
 }

--- a/modules/mesos-cluster/backups.tf
+++ b/modules/mesos-cluster/backups.tf
@@ -1,3 +1,34 @@
+variable "adminaccessrole-uid" {}
+
+data "aws_iam_policy_document" "marathon-backup-buckets-policy" {
+
+    statement {
+        effect = "Deny"
+        actions = [
+            "s3:*",
+        ]
+
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+
+        resources = [
+            "${aws_s3_bucket.marathon-duplicity-backups.arn}",
+            "${aws_s3_bucket.marathon-duplicity-backups.arn}/*"
+        ]
+
+        condition {
+            test = "StringNotLike"
+            variable = "aws:userId"
+            values = [
+                "${var.adminaccessrole-uid}:*",
+                "${var.aws_account_id}"
+            ]
+        }
+    }
+}
+
 resource "aws_s3_bucket" "marathon-duplicity-backups" {
     bucket = "marathon-${var.environment}-duplicity-backup"
     acl = "private"
@@ -8,4 +39,9 @@ resource "aws_s3_bucket" "marathon-duplicity-backups" {
         project = "backup"
         env = "${var.environment}"
     }
+}
+
+resource "aws_s3_bucket_policy" "marathon-backup-buckets-policy-attachment" {
+  bucket = "${aws_s3_bucket.marathon-duplicity-backups.id}"
+  policy = "${data.aws_iam_policy_document.marathon-backup-buckets-policy.json}"
 }


### PR DESCRIPTION
- Allow CommunityOpsElevated role to access relevant buckets
- Add a policy to the Discourse buckets to only allow access from the discourse IAM users (this will break staging until we create a new user for it)
- Add a policy to all other buckets (currently unused) to allow access from root and AdminAccessRole