### PR TITLE
Add discourse.mozilla.org certificate

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "ssl_certificates" {
   type = "map"
   default = {
     community-sites-elb-us-east-1 = "arn:aws:acm:us-east-1:484535289196:certificate/6883a4b5-cc8d-4821-a8db-69fa5fc65e02"
-    mozilla-org-elb-us-east-1 = "arn:aws:acm:us-east-1:484535289196:certificate/73b4dc75-9193-4884-9967-7c575e640a69"
+    mozilla-org-elb-us-east-1 = "arn:aws:acm:us-east-1:484535289196:certificate/9fd503f9-7999-471c-8498-42fcdb08d668"
     mesos-elb-us-east-1 = "arn:aws:acm:us-east-1:484535289196:certificate/4564050c-36ce-47ff-8eb7-d0936d71d0f5"
     analytics-us-west-1 = "arn:aws:acm:us-west-1:484535289196:certificate/b09c28f0-a98e-409c-b614-be356e9c593c"
   }


### PR DESCRIPTION
- Use ACM issued certificates for mozilla.org sites