### PR TITLE
fix mozilla india distribution origin

### DIFF
--- a/distributions.tf
+++ b/distributions.tf
@@ -34,9 +34,9 @@ module "badges-mozilla-org" {
 module "mozillaindia-org" {
   source              = "git://github.com/mozilla/partinfra-terraform-cloudfrontssl.git"
 
-  origin_domain_name  = "devs.mozillaindia.org"
-  origin_path         = "/homepage"
-  origin_id           = "gh-pages-dev-mozillaindia-org"
+  origin_domain_name  = "mozillaindia.github.io"
+  origin_path         = "/"
+  origin_id           = "gh-pages-mozillaindia-github-io"
   alias               = "mozillaindia.org"
   comment             = "Bug 1344680"
   acm_certificate_arn = "${lookup(var.ssl_certificates, "community-sites-elb-${var.aws_region}")}"


### PR DESCRIPTION
Mozilla India had to make a number of changes on their end to make the CloudFront distribution work, this updates the configuration accordingly.