### PR TITLE
set discourse-tldr version to v2

### DIFF
--- a/modules/discourse-tldr/main.tf
+++ b/modules/discourse-tldr/main.tf
@@ -10,7 +10,7 @@ variable "discourse_tldr_api_username" {}
 variable "discourse_tldr_category" {}
 variable "discourse_tldr_url" {}
 variable "discourse_tldr_version" {
-  default = "v1"
+  default = "v2"
 }
 
 data "aws_iam_policy_document" "discourse-tldr-assume-role" {


### PR DESCRIPTION
https://github.com/mozilla/discourse-tldr/releases/tag/v2

@akatsoulas, @johngian if this could be put in prod before thursday evening so we can catch the next tl;dr newsletter with it, that would be excellent!