### PR TITLE
update discourse-tldr to v3

### DIFF
--- a/modules/discourse-tldr/main.tf
+++ b/modules/discourse-tldr/main.tf
@@ -10,7 +10,7 @@ variable "discourse_tldr_api_username" {}
 variable "discourse_tldr_category" {}
 variable "discourse_tldr_url" {}
 variable "discourse_tldr_version" {
-  default = "v2"
+  default = "v3"
 }
 
 data "aws_iam_policy_document" "discourse-tldr-assume-role" {


### PR DESCRIPTION
Currently the script isn't working due to the mailchimp links being updated to https - this version fixes that, and should mean normal operation resumes.