### PR TITLE
set up discourse backup bucket

### DIFF
--- a/modules/discourse/backups.tf
+++ b/modules/discourse/backups.tf
@@ -1,0 +1,52 @@
+variable "environment" {}
+
+resource "aws_s3_bucket" "discourse-backup" {
+    bucket = "discourse-paas-${var.environment}-backup"
+    acl = "private"
+
+    lifecycle_rule {
+        id = "data_retention"
+        enabled = true
+        expiration {
+            days = 180
+        }
+    }
+
+    tags {
+        Name = "discourse-paas-${var.environment}-backup"
+        app = "discourse"
+        env = "${var.environment}"
+        project = "discourse"
+    }
+}
+
+data "aws_iam_policy_document" "discourse-backup-bucket-policy" {
+
+    statement {
+        effect = "Deny"
+        actions = [
+            "s3:*",
+        ]
+
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+
+        resources = [
+            "${aws_s3_bucket.discourse-backup.arn}",
+            "${aws_s3_bucket.discourse-backup.arn}/*",
+        ]
+
+        condition {
+            test = "StringNotLike"
+            variable = "aws:userId"
+            values = [
+                "${aws_iam_role.admin-access-role.unique_id}:*",
+                "${lookup(var.unmanaged_role_ids, "admin-ec2-role")}:*",
+                "${lookup(var.unmanaged_role_ids, "InfosecSecurityAuditRole")}:*",
+                "${var.aws_account_id}"
+            ]
+        }
+    }
+}

--- a/modules/discourse/iam.tf
+++ b/modules/discourse/iam.tf
@@ -26,6 +26,18 @@ data "aws_iam_policy_document" "policy-document" {
     statement {
         effect  = "Allow"
         actions = [
+            "s3:PutObject",
+        ]
+
+        resources = [
+            "${aws_s3_bucket.discourse-backup.arn}",
+            "${aws_s3_bucket.discourse-backup.arn}/*",
+        ]
+    }
+
+    statement {
+        effect  = "Allow"
+        actions = [
             "ses:SendRawEmail",
         ]
 


### PR DESCRIPTION
The aim here is to give Discourse permissions to create backups, but restrict the download of backups to the most minimal set of people possible.

Recklessly copied a bit of code from the jenkins backup bucket policy, so I'm not totally sure if that's what I'm doing.