### PR TITLE
Add new instances for migrating bitergia to ES 6.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "aws_amis" {
     us-east-1-ubuntu-16-04 = "ami-80861296"
     jenkins-2017-10-04 = "ami-9f1bdee5"
     bitergia-2017-10-16 = "ami-80b381e0"
+    bitergia-2018-10-01 = "ami-0f0674cb683fcc1f7"
   }
 }
 


### PR DESCRIPTION
* 2 new EC2 instances (web-services, data-collector)
* 1 new ES v6.2 elasticsearch domain
* Add VPC support for ES domain