### PR TITLE
don't cache 502-4 codes on discourse cdn

### DIFF
--- a/modules/discourse/main.tf
+++ b/modules/discourse/main.tf
@@ -83,6 +83,18 @@ module "discourse-cdn" {
     {
       error_caching_min_ttl = 0
       error_code = 404
+    },
+    {
+      error_caching_min_ttl = 0
+      error_code = 502
+    },
+    {
+      error_caching_min_ttl = 0
+      error_code = 503
+    },
+    {
+      error_caching_min_ttl = 0
+      error_code = 504
     }
   ]
 }


### PR DESCRIPTION
@johngian we hit the "white screen of death" on another one of our recent deploys from a 503. And I've thrown another couple of error codes in there just for luck. Let me know if you think I should throw *all* the supported codes in, or if you think that's excessive.

Already made the change manually in AWS, this is just to ensure it persists.