### PR TITLE
Remove X-Frame-Options for Activate

### DIFF
--- a/distributions.tf
+++ b/distributions.tf
@@ -11,7 +11,6 @@ module "activate-mozilla-community" {
         enabled = true
         hsts-enabled = true
         x-content-type-enabled = true
-        x-frame-options-enabled = true
         x-xss-protection-enabled = true
     }
 }


### PR DESCRIPTION
We will need a special case X-Frame-Options value for Pontoon as described here: https://developer.mozilla.org/en-US/docs/Mozilla/Implementing_Pontoon_in_a_Mozilla_website#B._(optional)_Enable_in-page_localization_of_your_web_project

It doesn't seem possible to pass values to the terraform module (https://github.com/mozilla/partinfra-terraform-cloudfrontssl/blob/secureheaders/headers_function.js#L10), therefore I disable the header completely. As Activate is a static site without anything that would trigger a remote action, this should be fine.