### PR TITLE
upgrade confluence to t2.large

### DIFF
--- a/confluence.tf
+++ b/confluence.tf
@@ -68,7 +68,7 @@ resource "aws_instance" "mcws-confluence" {
     provider          = "aws.us-east-2"
     provider          = "aws.us-east-2"
     ami               = "ami-0f65671a86f061fcd"
-    instance_type     = "t2.medium"
+    instance_type     = "t2.large"
     key_name          = "mcws"
     security_groups   = ["mcws-confluence-public-ec2-sg"]
     disable_api_termination = true


### PR DESCRIPTION
per [bug 1471218](https://bugzilla.mozilla.org/show_bug.cgi?id=1471218), they need a larger instance. it looks like terraform supports changing the instance type, correct? 